### PR TITLE
Add DeepL SE key

### DIFF
--- a/trust_db.ml
+++ b/trust_db.ml
@@ -210,4 +210,7 @@ let hints = String.Map.of_list [
     "This is the signing key for apps.0install.net, a repository of common \
      tools, libraries and runtime environments run by the 0install.net \
      project.";
+
+    "6F2BA466746148A09EA1B9CD40BD2489FD4754F0",
+    "This is the official key of DeepL SE (https://www.deepl.com/).";
   ]


### PR DESCRIPTION
DeepL publish a 0install feed for their Windows desktop app at https://appdownload.deepl.com/windows/0install/deepl.xml. They use a key with the fingerprint `6F2BA466746148A09EA1B9CD40BD2489FD4754F0` for signing their feeds.